### PR TITLE
fix: incremental module installation with deduplication

### DIFF
--- a/api/v1/odoodeployment_funcs.go
+++ b/api/v1/odoodeployment_funcs.go
@@ -230,10 +230,29 @@ func (o *OdooDeployment) GetPodSpec() corev1.PodSpec {
 	return podSpec
 }
 
+// DeduplicateModules removes duplicate entries from Spec.Modules in place,
+// preserving the original order of first occurrences.
+func (o *OdooDeployment) DeduplicateModules() {
+	seen := make(map[string]struct{}, len(o.Spec.Modules))
+	unique := make([]string, 0, len(o.Spec.Modules))
+	for _, m := range o.Spec.Modules {
+		if _, exists := seen[m]; !exists {
+			seen[m] = struct{}{}
+			unique = append(unique, m)
+		}
+	}
+	o.Spec.Modules = unique
+}
+
 func (o *OdooDeployment) GetDbInitJobTemplate() (batchv1.Job, []string) {
+	// Only install modules that have not previously been installed
+	modulesToInstall := utils.Difference(o.Spec.Modules, o.Status.InitModulesInstalled)
+	if len(modulesToInstall) == 0 {
+		return batchv1.Job{}, []string{}
+	}
 	stringFormattedInitModules := ""
 	// Add the init modules to the string
-	for _, module := range o.Spec.Modules {
+	for _, module := range modulesToInstall {
 		stringFormattedInitModules += fmt.Sprintf("%s,", module)
 	}
 	// Remove the last comma
@@ -265,7 +284,7 @@ func (o *OdooDeployment) GetDbInitJobTemplate() (batchv1.Job, []string) {
 			BackoffLimit: func(i int32) *int32 { return &i }(2),
 		},
 	}
-	return job, o.Spec.Modules
+	return job, modulesToInstall
 }
 
 func (o *OdooConfig) GetSerializedOdooConfig(

--- a/api/v1/odoodeployment_funcs_test.go
+++ b/api/v1/odoodeployment_funcs_test.go
@@ -1,0 +1,128 @@
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// minimalOdooDeployment returns an OdooDeployment with just enough fields
+// set to call GetDbInitJobTemplate without panicking.
+func minimalOdooDeployment(specModules, installedModules []string) *OdooDeployment {
+	return &OdooDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-odoo",
+			Namespace: "default",
+		},
+		Spec: OdooDeploymentSpec{
+			Image: "odoo:18",
+			Config: OdooConfig{
+				DataDir: "/var/lib/odoo",
+			},
+			Modules: specModules,
+		},
+		Status: OdooDeploymentStatus{
+			OdooDataPvcName:      "test-odoo",
+			OdooConfigSecretName: "test-odoo-config",
+			InitModulesInstalled: installedModules,
+		},
+	}
+}
+
+func TestGetDbInitJobTemplate_FreshInstall(t *testing.T) {
+	o := minimalOdooDeployment(
+		[]string{"base", "web", "sale"},
+		[]string{},
+	)
+
+	job, modules := o.GetDbInitJobTemplate()
+
+	if len(modules) != 3 {
+		t.Fatalf("expected 3 modules, got %d: %v", len(modules), modules)
+	}
+	cmd := job.Spec.Template.Spec.Containers[0].Command
+	initFlag := cmd[len(cmd)-1]
+	if !strings.Contains(initFlag, "base") || !strings.Contains(initFlag, "web") || !strings.Contains(initFlag, "sale") {
+		t.Errorf("--init flag %q missing expected modules", initFlag)
+	}
+}
+
+func TestGetDbInitJobTemplate_PartialInstall(t *testing.T) {
+	o := minimalOdooDeployment(
+		[]string{"base", "web", "sale"},
+		[]string{"base", "web"},
+	)
+
+	job, modules := o.GetDbInitJobTemplate()
+
+	if len(modules) != 1 || modules[0] != "sale" {
+		t.Fatalf("expected [sale], got %v", modules)
+	}
+	cmd := job.Spec.Template.Spec.Containers[0].Command
+	initFlag := cmd[len(cmd)-1]
+	if initFlag != "sale" {
+		t.Errorf("--init flag = %q, want %q", initFlag, "sale")
+	}
+}
+
+func TestGetDbInitJobTemplate_AllInstalled(t *testing.T) {
+	o := minimalOdooDeployment(
+		[]string{"base", "web"},
+		[]string{"base", "web"},
+	)
+
+	job, modules := o.GetDbInitJobTemplate()
+
+	if len(modules) != 0 {
+		t.Fatalf("expected empty modulesToInstall, got %v", modules)
+	}
+	// Job should be zero-value — no panic
+	if job.Name != "" {
+		t.Errorf("expected empty Job, got Name=%q", job.Name)
+	}
+}
+
+func TestDeduplicateModules(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "no duplicates unchanged",
+			input: []string{"base", "web", "sale"},
+			want:  []string{"base", "web", "sale"},
+		},
+		{
+			name:  "duplicates removed preserving order",
+			input: []string{"base", "web", "base", "sale", "web"},
+			want:  []string{"base", "web", "sale"},
+		},
+		{
+			name:  "all duplicates reduced to one",
+			input: []string{"base", "base", "base"},
+			want:  []string{"base"},
+		},
+		{
+			name:  "empty slice unchanged",
+			input: []string{},
+			want:  []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := minimalOdooDeployment(tc.input, []string{})
+			o.DeduplicateModules()
+			if len(o.Spec.Modules) != len(tc.want) {
+				t.Fatalf("DeduplicateModules() = %v, want %v", o.Spec.Modules, tc.want)
+			}
+			for i := range o.Spec.Modules {
+				if o.Spec.Modules[i] != tc.want[i] {
+					t.Errorf("Modules[%d] = %q, want %q", i, o.Spec.Modules[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/config/samples/odoo_v1_odoodeployment.yaml
+++ b/config/samples/odoo_v1_odoodeployment.yaml
@@ -40,8 +40,7 @@ spec:
     limitMemorySoft: 2147483648
     limitMemoryHard: 2684354560
   odooFilestore:
-    name: odoo-filestore
-    storageClassName: default
+    storageClassName: standard
     accessModes:
       - ReadWriteOnce
     size: 10Gi

--- a/internal/controller/odoodeployment_controller.go
+++ b/internal/controller/odoodeployment_controller.go
@@ -112,6 +112,8 @@ func (r *OdooDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		"resourceVersion", odooDeployment.ResourceVersion,
 		"generation", odooDeployment.Generation)
 
+	odooDeployment.DeduplicateModules()
+
 	odooAdminSecretReconciler := reconcileloops.OdooAdminPasswordSecretReconciler{
 		Client:         r.Client,
 		Scheme:         r.Scheme,

--- a/internal/controller/reconcileloops/databaseinitjob.go
+++ b/internal/controller/reconcileloops/databaseinitjob.go
@@ -53,10 +53,11 @@ func (r *OdooDatabaseInitJobReconciler) Reconcile(ctx context.Context, req ctrl.
 		// If job succeeded, update the status of the OdooDeployment
 		if currentInitJob.Status.Succeeded > 0 {
 			// The current init job has succeeded, so we can clear it
-			logger.Info("Current InitJob succeeded, clearing")
+			logger.Info("Current InitJob succeeded")
+			logger.Info("New modules installed: " + fmt.Sprint(r.OdooDeployment.Status.CurrentInitJob.Modules))
 			r.OdooDeployment.Status.CurrentInitJob.Name = ""
 			r.OdooDeployment.Status.CurrentInitJob.Namespace = ""
-			r.OdooDeployment.Status.InitModulesInstalled = r.OdooDeployment.Status.CurrentInitJob.Modules
+			r.OdooDeployment.Status.InitModulesInstalled = append(r.OdooDeployment.Status.InitModulesInstalled, r.OdooDeployment.Status.CurrentInitJob.Modules...)
 			r.OdooDeployment.Status.CurrentInitJob.Modules = []string{}
 			utils.UpdateStatus(&r.OdooDeployment.Status.Conditions, "OperatorSucceeded", "InitJobSucceeded", "InitJob succeeded, clearing", metav1.ConditionTrue)
 
@@ -105,11 +106,12 @@ func (r *OdooDatabaseInitJobReconciler) Reconcile(ctx context.Context, req ctrl.
 	// If the list is empty, create a new InitJob to install all modules
 	// If the list is the same, do nothing
 	logger.V(1).Info(fmt.Sprintf("Currently installed modules: %d", len(r.OdooDeployment.Status.InitModulesInstalled)))
-	if len(r.OdooDeployment.Status.InitModulesInstalled) == 0 || len(r.OdooDeployment.Status.InitModulesInstalled) != len(r.OdooDeployment.Spec.Modules) {
+	if len(utils.Difference(r.OdooDeployment.Spec.Modules, r.OdooDeployment.Status.InitModulesInstalled)) > 0 {
 		// Create a new InitJob to install all modules
 		logger.Info("Creating a new InitJob to install modules")
 
 		initJob, modulesToInstall := r.OdooDeployment.GetDbInitJobTemplate()
+		logger.Info("New modules to install: " + fmt.Sprint(modulesToInstall))
 		ctrl.SetControllerReference(r.OdooDeployment, &initJob, r.Scheme)
 
 		err := r.Create(ctx, &initJob)

--- a/internal/controller/reconcileloops/databaseinitjob_test.go
+++ b/internal/controller/reconcileloops/databaseinitjob_test.go
@@ -1,0 +1,282 @@
+package reconcileloops
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	odoov1 "github.com/MohanadAbugharbia/odoo-operator/api/v1"
+)
+
+// specCounter generates unique resource names per test so that lingering
+// objects from one test (envtest has no GC) never collide with the next.
+var specCounter int64
+
+var _ = Describe("DatabaseInitJob Reconcile Loop", func() {
+	var (
+		reconciler         *OdooDatabaseInitJobReconciler
+		ctx                context.Context
+		req                reconcile.Request
+		odooDeployment     *odoov1.OdooDeployment
+		resourceName       string
+		typeNamespacedName types.NamespacedName
+	)
+
+	const resourceNamespace = "default"
+
+	ctx = context.Background()
+
+	newOdooDeployment := func(name string, specModules []string) *odoov1.OdooDeployment {
+		return &odoov1.OdooDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resourceNamespace,
+			},
+			Spec: odoov1.OdooDeploymentSpec{
+				Replicas: 1,
+				Image:    "mohanadabugharbia/odoo:18",
+				OdooFilestore: odoov1.PersistentVolumeClaimSpec{
+					Size: resource.MustParse("1Gi"),
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+				},
+				Database: odoov1.OdooDatabaseConfig{
+					HostFromSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-dbinitjob-db-secret"},
+						Key:                  "host",
+					},
+					PortFromSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-dbinitjob-db-secret"},
+						Key:                  "port",
+					},
+					UserFromSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-dbinitjob-db-secret"},
+						Key:                  "user",
+					},
+					PasswordFromSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-dbinitjob-db-secret"},
+						Key:                  "password",
+					},
+					NameFromSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-dbinitjob-db-secret"},
+						Key:                  "name",
+					},
+					SSLFromSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-dbinitjob-db-secret"},
+						Key:                  "ssl",
+					},
+					MaxConnFromSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-dbinitjob-db-secret"},
+						Key:                  "maxconn",
+					},
+				},
+				Modules: specModules,
+				Config: odoov1.OdooConfig{
+					DataDir: "/var/lib/odoo",
+				},
+			},
+		}
+	}
+
+	// tryDelete issues a Delete and tolerates "not found" — used in AfterEach
+	// where the reconciler may have already deleted the object.
+	tryDelete := func(obj client.Object) {
+		err := k8sClient.Delete(ctx, obj)
+		if err != nil && !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	BeforeEach(func() {
+		n := atomic.AddInt64(&specCounter, 1)
+		resourceName = fmt.Sprintf("test-dij-%d", n)
+		typeNamespacedName = types.NamespacedName{Name: resourceName, Namespace: resourceNamespace}
+
+		By("creating the OdooDeployment CR")
+		odooDeployment = newOdooDeployment(resourceName, []string{"base", "web"})
+		Expect(k8sClient.Create(ctx, odooDeployment)).To(Succeed())
+
+		By("creating the PVC for the OdooDeployment")
+		pvc := odooDeployment.GetPvcTemplate()
+		Expect(k8sClient.Create(ctx, &pvc)).To(Succeed())
+		odooDeployment.Status.OdooDataPvcName = pvc.Name
+		Expect(k8sClient.Status().Update(ctx, odooDeployment)).To(Succeed())
+
+		By("creating the config secret for the OdooDeployment")
+		configSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      odooDeployment.Name + "-config",
+				Namespace: resourceNamespace,
+			},
+			Data: map[string][]byte{"odoo.conf": []byte("[options]")},
+		}
+		Expect(k8sClient.Create(ctx, &configSecret)).To(Succeed())
+		odooDeployment.Status.OdooConfigSecretName = configSecret.Name
+		Expect(k8sClient.Status().Update(ctx, odooDeployment)).To(Succeed())
+
+		reconciler = &OdooDatabaseInitJobReconciler{
+			Client:         k8sClient,
+			Scheme:         k8sClient.Scheme(),
+			OdooDeployment: odooDeployment,
+		}
+		req = ctrl.Request{
+			NamespacedName: client.ObjectKey{Name: resourceName, Namespace: resourceNamespace},
+		}
+	})
+
+	AfterEach(func() {
+		By("deleting the init job if it exists")
+		job := &batchv1.Job{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: resourceName + "-init", Namespace: resourceNamespace}, job); err == nil {
+			tryDelete(job)
+		}
+
+		By("deleting the config secret")
+		secret := &corev1.Secret{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: resourceName + "-config", Namespace: resourceNamespace}, secret); err == nil {
+			tryDelete(secret)
+		}
+
+		By("deleting the PVC")
+		pvc := odooDeployment.GetPvcTemplate()
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, &pvc); err == nil {
+			tryDelete(&pvc)
+		}
+
+		By("deleting the OdooDeployment CR")
+		od := &odoov1.OdooDeployment{}
+		if err := k8sClient.Get(ctx, typeNamespacedName, od); err == nil {
+			tryDelete(od)
+		}
+	})
+
+	// Scenario A: no modules installed → job created with all spec modules
+	It("A: creates an InitJob with all spec modules when nothing is installed", func() {
+		_, _, requeue := reconciler.Reconcile(ctx, req)
+
+		Expect(requeue).To(BeTrue())
+		Expect(odooDeployment.Status.CurrentInitJob.Modules).To(ConsistOf("base", "web"))
+
+		job := &batchv1.Job{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      resourceName + "-init",
+			Namespace: resourceNamespace,
+		}, job)).To(Succeed())
+	})
+
+	// Scenario B: some modules already installed → job contains only the delta
+	It("B: creates an InitJob with only new modules when some are already installed", func() {
+		odooDeployment.Status.InitModulesInstalled = []string{"base"}
+		Expect(k8sClient.Status().Update(ctx, odooDeployment)).To(Succeed())
+
+		reconciler.OdooDeployment = odooDeployment
+		_, _, requeue := reconciler.Reconcile(ctx, req)
+
+		Expect(requeue).To(BeTrue())
+		Expect(odooDeployment.Status.CurrentInitJob.Modules).To(ConsistOf("web"))
+
+		job := &batchv1.Job{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      resourceName + "-init",
+			Namespace: resourceNamespace,
+		}, job)).To(Succeed())
+	})
+
+	// Scenario B': same-length module replacement — e.g. ["base","web"] → ["base","crm"]
+	It("B': creates an InitJob when spec modules changed to different modules with same count", func() {
+		odooDeployment.Status.InitModulesInstalled = []string{"base", "web"}
+		Expect(k8sClient.Status().Update(ctx, odooDeployment)).To(Succeed())
+
+		odooDeployment.Spec.Modules = []string{"base", "crm"}
+		Expect(k8sClient.Update(ctx, odooDeployment)).To(Succeed())
+
+		reconciler.OdooDeployment = odooDeployment
+		_, _, requeue := reconciler.Reconcile(ctx, req)
+
+		Expect(requeue).To(BeTrue())
+		Expect(odooDeployment.Status.CurrentInitJob.Modules).To(ConsistOf("crm"))
+	})
+
+	// Scenario C: all spec modules already installed → no job, no requeue
+	It("C: does not create an InitJob when all modules are already installed", func() {
+		odooDeployment.Status.InitModulesInstalled = []string{"base", "web"}
+		Expect(k8sClient.Status().Update(ctx, odooDeployment)).To(Succeed())
+
+		reconciler.OdooDeployment = odooDeployment
+		_, _, requeue := reconciler.Reconcile(ctx, req)
+
+		Expect(requeue).To(BeFalse())
+
+		job := &batchv1.Job{}
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      resourceName + "-init",
+			Namespace: resourceNamespace,
+		}, job)
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	// Scenario D: duplicate modules in spec → dedup applied, job has unique modules only
+	It("D: deduplicates spec modules before creating the InitJob", func() {
+		odooDeployment.Spec.Modules = []string{"base", "web", "base", "web"}
+		Expect(k8sClient.Update(ctx, odooDeployment)).To(Succeed())
+		odooDeployment.DeduplicateModules()
+
+		reconciler.OdooDeployment = odooDeployment
+		_, _, requeue := reconciler.Reconcile(ctx, req)
+
+		Expect(requeue).To(BeTrue())
+		Expect(odooDeployment.Status.CurrentInitJob.Modules).To(ConsistOf("base", "web"))
+		Expect(odooDeployment.Status.CurrentInitJob.Modules).To(HaveLen(2))
+	})
+
+	// Scenario E: job succeeded → InitModulesInstalled grows by append, not replace
+	It("E: appends modules to InitModulesInstalled when job succeeds", func() {
+		odooDeployment.Status.InitModulesInstalled = []string{"base"}
+		odooDeployment.Status.CurrentInitJob = odoov1.DBInitjob{
+			Name:      resourceName + "-init",
+			Namespace: resourceNamespace,
+			Modules:   []string{"web"},
+		}
+		Expect(k8sClient.Status().Update(ctx, odooDeployment)).To(Succeed())
+
+		succeededJob := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName + "-init",
+				Namespace: resourceNamespace,
+			},
+			Spec: batchv1.JobSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers:    []corev1.Container{{Name: "init", Image: "odoo:18"}},
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, succeededJob)).To(Succeed())
+		succeededJob.Status.Succeeded = 1
+		Expect(k8sClient.Status().Update(ctx, succeededJob)).To(Succeed())
+
+		reconciler.OdooDeployment = odooDeployment
+		_, _, requeue := reconciler.Reconcile(ctx, req)
+
+		Expect(requeue).To(BeTrue())
+		Expect(odooDeployment.Status.InitModulesInstalled).To(ConsistOf("base", "web"))
+		Expect(odooDeployment.Status.CurrentInitJob.Name).To(BeEmpty())
+		Expect(odooDeployment.Status.CurrentInitJob.Modules).To(BeEmpty())
+	})
+})

--- a/pkg/utils/generic.go
+++ b/pkg/utils/generic.go
@@ -1,0 +1,16 @@
+package utils
+
+// Difference returns the elements in `a` that aren't in `b`.
+func Difference(a, b []string) []string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[x] = struct{}{}
+	}
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
+}

--- a/pkg/utils/generic_test.go
+++ b/pkg/utils/generic_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestDifference(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{
+			name: "b empty returns all of a",
+			a:    []string{"base", "web", "sale"},
+			b:    []string{},
+			want: []string{"base", "web", "sale"},
+		},
+		{
+			name: "a and b identical returns empty",
+			a:    []string{"base", "web"},
+			b:    []string{"base", "web"},
+			want: nil,
+		},
+		{
+			name: "b is strict subset of a returns delta",
+			a:    []string{"base", "web", "sale"},
+			b:    []string{"base", "web"},
+			want: []string{"sale"},
+		},
+		{
+			name: "a empty returns empty",
+			a:    []string{},
+			b:    []string{"base"},
+			want: nil,
+		},
+		{
+			name: "b has elements not in a returns only unmatched elements of a",
+			a:    []string{"base", "web"},
+			b:    []string{"base", "crm"},
+			want: []string{"web"},
+		},
+		{
+			name: "duplicates in a are preserved as-is",
+			a:    []string{"base", "base", "web"},
+			b:    []string{"base"},
+			want: []string{"web"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Difference(tc.a, tc.b)
+			if len(got) != len(tc.want) {
+				t.Fatalf("Difference(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("Difference(%v, %v)[%d] = %q, want %q", tc.a, tc.b, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                             
                                                            
  - Replace full-list module reinstallation with incremental installs: the init Job now only installs modules not yet present in Status.InitModulesInstalled, computed via a new utils.Difference helper
  - Accumulate installed modules with append instead of overwriting InitModulesInstalled on each Job success, so the record of installed modules is preserved across multiple init cycles                
  - Add DeduplicateModules() called at the top of the main reconcile loop to normalise Spec.Modules before any sub-reconciler runs, preventing duplicate --init flags and spurious re-installs           
  - Fix the gate condition in the init Job reconciler from a length-based check to a content-aware Difference check — previously, swapping modules of the same count (e.g. ["base","web"] →              
  ["base","crm"]) would silently skip installation of the new module                                                                                                                                     
  - Guard GetDbInitJobTemplate against a panic on empty modulesToInstall by returning early before the string slice operation                                                                            
                                                                                                                                                                                                         
  ## Test plan                                              
                                                                                                                                                                                                         
  - pkg/utils/generic_test.go — 6 table-driven unit tests for Difference covering empty inputs, identical slices, subsets, and duplicates                                                                
  - api/v1/odoodeployment_funcs_test.go — unit tests for GetDbInitJobTemplate (fresh install, partial install, fully installed / no panic) and 4 cases for DeduplicateModules
  - internal/controller/reconcileloops/databaseinitjob_test.go — 5 integration tests via envtest:                                                                                                        
    - A: fresh install → job with all spec modules                                                                                                                                                       
    - B: partial install → job with delta only                                                                                                                                                           
    - B': same-length module replacement → job with new module (regression for the gate condition fix)                                                                                                   
    - C: all installed → no job created                                                                                                                                                                  
    - D: duplicate spec modules → deduped before job creation                                                                                                                                            
    - E: job success → InitModulesInstalled appended, not replaced                                                                                                                                       
                                       