### PR TITLE
fix: reset lower version components on minor/major bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,12 @@ jobs:
           if [[ ${{ github.event.inputs.version }} == 'major' ]]
           then
             VNUM1=$((VNUM1+1))
+            VNUM2=0
+            VNUM3=0
           elif [[ ${{ github.event.inputs.version }} == 'minor' ]]
           then
             VNUM2=$((VNUM2+1))
+            VNUM3=0
           elif [[ ${{ github.event.inputs.version }} == 'patch' ]]
           then
             VNUM3=$((VNUM3+1))


### PR DESCRIPTION
## Summary

  - When bumping the minor version, the patch component was not reset to 0 (e.g. 0.0.6 → 0.1.6 instead of 0.1.0)
  - Minor bumps now reset patch to 0
  - Major bumps now reset both minor and patch to 0

## Root Cause

The Get the next version step in the release workflow incremented the target version component but left the lower components unchanged, violating semver semantics.