### PR TITLE
fix: watch owned Job events to trigger reconcile on deletion

### DIFF
--- a/internal/controller/odoodeployment_controller.go
+++ b/internal/controller/odoodeployment_controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -227,6 +228,7 @@ func (r *OdooDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&batchv1.Job{}).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.mapSecretsToOdooDeployments()),


### PR DESCRIPTION
## Problem

The controller was missing a watch on `batchv1.Job`. Deleting the init
job did not enqueue a reconcile, so the operator only noticed on its
next periodic requeue (up to 30s later) rather than reacting immediately.

## Change

Added `Owns(&batchv1.Job{})` in `SetupWithManager`. Because
`ctrl.SetControllerReference` is already called when the job is created,
the owner reference is already in place — this just tells the manager to
watch for it.

## Behaviour

Deleting the init job now immediately triggers a reconcile. The
reconciler detects the job is gone, finds that modules are still
uninstalled, and recreates the job.