### PR TITLE
feat: make Odoo container command configurable via OdooCommand spec field

### DIFF
--- a/api/v1/odoodeployment_funcs.go
+++ b/api/v1/odoodeployment_funcs.go
@@ -152,7 +152,7 @@ func (o *OdooDeployment) GetPodSpec() corev1.PodSpec {
 				ImagePullPolicy: o.Spec.ImagePullPolicy,
 
 				Command: []string{
-					"/entrypoint.sh",
+					o.Spec.OdooCommand,
 					"-c",
 					"/opt/odoo/odoo.conf",
 				},
@@ -261,7 +261,7 @@ func (o *OdooDeployment) GetDbInitJobTemplate() (batchv1.Job, []string) {
 
 	spec := o.GetPodSpec()
 	spec.Containers[0].Command = []string{
-		"/entrypoint.sh",
+		o.Spec.OdooCommand,
 		"-c",
 		"/opt/odoo/odoo.conf",
 		"--stop-after-init",

--- a/api/v1/odoodeployment_funcs_test.go
+++ b/api/v1/odoodeployment_funcs_test.go
@@ -9,6 +9,8 @@ import (
 
 // minimalOdooDeployment returns an OdooDeployment with just enough fields
 // set to call GetDbInitJobTemplate without panicking.
+// OdooCommand is set to "odoo" to match the kubebuilder API-server default;
+// unit tests construct structs directly so the default is not applied automatically.
 func minimalOdooDeployment(specModules, installedModules []string) *OdooDeployment {
 	return &OdooDeployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -16,7 +18,8 @@ func minimalOdooDeployment(specModules, installedModules []string) *OdooDeployme
 			Namespace: "default",
 		},
 		Spec: OdooDeploymentSpec{
-			Image: "odoo:18",
+			Image:       "odoo:18",
+			OdooCommand: "odoo",
 			Config: OdooConfig{
 				DataDir: "/var/lib/odoo",
 			},
@@ -169,6 +172,88 @@ func TestDeduplicateModules(t *testing.T) {
 				if o.Spec.Modules[i] != tc.want[i] {
 					t.Errorf("Modules[%d] = %q, want %q", i, o.Spec.Modules[i], tc.want[i])
 				}
+			}
+		})
+	}
+}
+
+func TestGetPodSpec_OdooCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		odooCommand string
+		wantCmd     string
+	}{
+		{
+			name:        "default command",
+			odooCommand: "odoo",
+			wantCmd:     "odoo",
+		},
+		{
+			name:        "custom entrypoint script",
+			odooCommand: "/entrypoint.sh",
+			wantCmd:     "/entrypoint.sh",
+		},
+		{
+			name:        "alternate binary",
+			odooCommand: "odoo.bin",
+			wantCmd:     "odoo.bin",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := minimalOdooDeployment([]string{"base"}, []string{})
+			o.Spec.OdooCommand = tc.odooCommand
+
+			podSpec := o.GetPodSpec()
+
+			cmd := podSpec.Containers[0].Command
+			if len(cmd) == 0 {
+				t.Fatal("Command is empty")
+			}
+			if cmd[0] != tc.wantCmd {
+				t.Errorf("GetPodSpec Command[0] = %q, want %q", cmd[0], tc.wantCmd)
+			}
+		})
+	}
+}
+
+func TestGetDbInitJobTemplate_OdooCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		odooCommand string
+		wantCmd     string
+	}{
+		{
+			name:        "default command",
+			odooCommand: "odoo",
+			wantCmd:     "odoo",
+		},
+		{
+			name:        "custom entrypoint script",
+			odooCommand: "/entrypoint.sh",
+			wantCmd:     "/entrypoint.sh",
+		},
+		{
+			name:        "alternate binary",
+			odooCommand: "odoo.bin",
+			wantCmd:     "odoo.bin",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := minimalOdooDeployment([]string{"base"}, []string{})
+			o.Spec.OdooCommand = tc.odooCommand
+
+			job, _ := o.GetDbInitJobTemplate()
+
+			cmd := job.Spec.Template.Spec.Containers[0].Command
+			if len(cmd) == 0 {
+				t.Fatal("Command is empty")
+			}
+			if cmd[0] != tc.wantCmd {
+				t.Errorf("GetDbInitJobTemplate Command[0] = %q, want %q", cmd[0], tc.wantCmd)
 			}
 		})
 	}

--- a/api/v1/odoodeployment_types.go
+++ b/api/v1/odoodeployment_types.go
@@ -214,6 +214,12 @@ type OdooDeploymentSpec struct {
 
 	// The name of the OdooDployment
 	Name string `json:"name"`
+
+	// The command that runs odoo inside the container, if not specified it will default to "odoo"
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="odoo"
+	OdooCommand string `json:"odooCommand,omitempty"`
+
 	// The number of replicas to run for the OdooDployment
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1

--- a/config/crd/bases/odoo.abugharbia.com_odoodeployments.yaml
+++ b/config/crd/bases/odoo.abugharbia.com_odoodeployments.yaml
@@ -355,6 +355,11 @@ spec:
               name:
                 description: The name of the OdooDployment
                 type: string
+              odooCommand:
+                default: odoo
+                description: The command that runs odoo inside the container, if not
+                  specified it will default to "odoo"
+                type: string
               odooFilestore:
                 description: PersistentVolumeClaim defines the replicated volume specs
                 properties:

--- a/internal/controller/reconcileloops/deployment_test.go
+++ b/internal/controller/reconcileloops/deployment_test.go
@@ -294,4 +294,26 @@ var _ = Describe("Deployment Reconcile Loop", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(*deployment.Spec.Replicas).To(Equal(newReplicas))
 	})
+	It("should use a custom OdooCommand in the Deployment container", func() {
+		err := k8sClient.Get(ctx, typeNamespacedName, odooDeployment)
+		Expect(err).NotTo(HaveOccurred())
+		odooDeployment.Spec.OdooCommand = "/entrypoint.sh"
+		err = k8sClient.Update(ctx, odooDeployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		reconciler = &DeploymentReconciler{
+			Client:         k8sClient,
+			Scheme:         k8sClient.Scheme(),
+			OdooDeployment: odooDeployment,
+		}
+		req = ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      "test-odoo-deployment",
+				Namespace: "default",
+			},
+		}
+		deployment, err := reconciler.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Spec.Template.Spec.Containers[0].Command[0]).To(Equal("/entrypoint.sh"))
+	})
 })


### PR DESCRIPTION
## Summary

- Adds `odooCommand` to `OdooDeploymentSpec` (string, optional, defaults to `"odoo"`)
- Replaces the hardcoded `/entrypoint.sh` in `GetPodSpec` and `GetDbInitJobTemplate` with `o.Spec.OdooCommand`
- Regenerates the CRD manifest to expose the new field with its default

## Motivation

The operator previously assumed all Odoo images used `/entrypoint.sh` as their
entrypoint, which is specific to the official Odoo Docker image. Custom images
(e.g. those that ship `odoo` or `odoo.bin` directly on `PATH`) could not be used
without patching the operator. This field makes the command a first-class spec
concern with a safe default that matches prior behaviour.

## Test plan

- [x] Unit — `TestGetPodSpec_OdooCommand`: asserts `GetPodSpec().Containers[0].Command[0]`
      for default (`odoo`), custom script (`/entrypoint.sh`), and alternate binary (`odoo.bin`)
- [x] Unit — `TestGetDbInitJobTemplate_OdooCommand`: same three cases for the init Job container
- [x] Integration — new `It` block in `deployment_test.go`: sets `OdooCommand: "/entrypoint.sh"` on the live CR, reconciles, and asserts the Deployment container command reflects it
- [x] All existing tests continue to pass (`make test`)