### PR TITLE
feat: add configurable max_cron_threads to OdooConfig

### DIFF
--- a/api/v1/odoodeployment_funcs.go
+++ b/api/v1/odoodeployment_funcs.go
@@ -288,7 +288,7 @@ func (o *OdooConfig) GetSerializedOdooConfig(
 ) string {
 
 	serializedConfig := fmt.Sprintf(
-		"[options]\nadmin_passwd = %s\ndata_dir=%s\n\ndb_host = %s\ndb_port = %d\ndb_user = %s\ndb_password = %s\ndb_maxconn = %d\ndb_name= %s\n\ndebug_mode = %t\nwithout_demo = %t\nproxy_mode = %t\nworkers = %d\nlimit_memory_soft = %d\nlimit_memory_hard = %d\nlimit_request = %d\nlimit_time_cpu = %d\nlimit_time_real = %d\n",
+		"[options]\nadmin_passwd = %s\ndata_dir=%s\n\ndb_host = %s\ndb_port = %d\ndb_user = %s\ndb_password = %s\ndb_maxconn = %d\ndb_name= %s\n\ndebug_mode = %t\nwithout_demo = %t\nproxy_mode = %t\nworkers = %d\nlimit_memory_soft = %d\nlimit_memory_hard = %d\nlimit_request = %d\nlimit_time_cpu = %d\nlimit_time_real = %d\nmax_cron_threads = %d\n",
 		adminPassword,
 		o.DataDir,
 		dbHost,
@@ -306,6 +306,7 @@ func (o *OdooConfig) GetSerializedOdooConfig(
 		o.LimitRequest,
 		o.LimitTimeCPU,
 		o.LimitTimeReal,
+		o.MaxCronThreads,
 	)
 	if len(extraAddonsPaths) > 0 {
 		serializedConfig += fmt.Sprintf("addons_path = %s\n", strings.Join(extraAddonsPaths, ","))

--- a/api/v1/odoodeployment_funcs_test.go
+++ b/api/v1/odoodeployment_funcs_test.go
@@ -21,7 +21,8 @@ func minimalOdooDeployment(specModules, installedModules []string) *OdooDeployme
 			Image:       "odoo:18",
 			OdooCommand: []string{"odoo"},
 			Config: OdooConfig{
-				DataDir: "/var/lib/odoo",
+				DataDir:        "/var/lib/odoo",
+				MaxCronThreads: 1,
 			},
 			Modules: specModules,
 		},
@@ -128,6 +129,41 @@ func TestGetSerializedOdooConfig_ExtraAddonsPaths(t *testing.T) {
 			}
 			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
 				t.Errorf("config unexpectedly contains %q\ngot:\n%s", tc.wantAbsent, got)
+			}
+		})
+	}
+}
+
+func TestGetSerializedOdooConfig_MaxCronThreads(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxCronThreads int32
+		wantContains   string
+	}{
+		{
+			name:           "default 1 thread",
+			maxCronThreads: 1,
+			wantContains:   "max_cron_threads = 1\n",
+		},
+		{
+			name:           "custom 4 threads",
+			maxCronThreads: 4,
+			wantContains:   "max_cron_threads = 4\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &OdooConfig{
+				DataDir:        "/var/lib/odoo",
+				MaxCronThreads: tc.maxCronThreads,
+			}
+			got := cfg.GetSerializedOdooConfig(
+				"adminpass", "localhost", 5432, "odoo", "dbpass", 20, "odoo",
+				[]string{},
+			)
+			if !strings.Contains(got, tc.wantContains) {
+				t.Errorf("config missing %q\ngot:\n%s", tc.wantContains, got)
 			}
 		})
 	}

--- a/api/v1/odoodeployment_types.go
+++ b/api/v1/odoodeployment_types.go
@@ -184,6 +184,10 @@ type OdooConfig struct {
 	// +kubebuilder:default=2684354560
 	LimitMemoryHard int64 `json:"limitMemoryHard,omitempty"`
 
+	// The maximum number of cron threads to use for Odoo
+	// +kubebuilder:default=1
+	MaxCronThreads int32 `json:"maxCronThreads,omitempty"`
+
 	// Extra addons paths for Odoo. Each entry must be an absolute path with no commas, spaces, newlines, or # characters.
 	// +kubebuilder:validation:Optional
 	// +listType=set

--- a/config/crd/bases/odoo.abugharbia.com_odoodeployments.yaml
+++ b/config/crd/bases/odoo.abugharbia.com_odoodeployments.yaml
@@ -95,6 +95,11 @@ spec:
                       can take
                     format: int32
                     type: integer
+                  maxCronThreads:
+                    default: 1
+                    description: The maximum number of cron threads to use for Odoo
+                    format: int32
+                    type: integer
                   proxyMode:
                     default: true
                     description: |-

--- a/config/samples/odoo_v1_odoodeployment.yaml
+++ b/config/samples/odoo_v1_odoodeployment.yaml
@@ -39,6 +39,7 @@ spec:
     limitTimeReal: 120
     limitMemorySoft: 2147483648
     limitMemoryHard: 2684354560
+    maxCronThreads: 1
   odooFilestore:
     storageClassName: standard
     accessModes:


### PR DESCRIPTION
## Summary

- Adds `maxCronThreads` field to `OdooConfig` (kubebuilder default: 1) to control the number of Odoo cron worker threads
- Serializes the field into `odoo.conf` as `max_cron_threads`
- Updates CRD manifest and sample CR

## Test plan

- [x] `TestGetSerializedOdooConfig_MaxCronThreads` covers default (1) and custom (4) values
- [x] `minimalOdooDeployment` updated to explicitly set `MaxCronThreads: 1` so unit tests don't silently exercise the zero value
- [x] `make manifests` was run — CRD YAML reflects the new field